### PR TITLE
#6 ngx-simple-tools published to npm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # Optional environmental variables
 
 REPO=dronasys-com
-APP=ngx-simple-lib
+APP=ngx-simple-tools
 ANGULAR_CLI_DEV=angular-cli-headless-chrome
 
 BUILD_VER ?= a1.0.0
@@ -24,16 +24,16 @@ help: ## This help.
 .DEFAULT_GOAL := help
 
 build: ## build all libraries in this project
-	ng build ngx-simple-lib
+	ng build ngx-simple-tools
 
 test: ## run angular tests, if you are running within docker, container must container chromium headless
-	ng test ngx-simple-lib
+	ng test ngx-simple-tools
 
 run-lib: ## run the lib watching for changes
-	ng build ngx-simple-lib --watch
+	ng build ngx-simple-tools --watch
 
 run: ## runs the angular demo project
 	ng serve
 	
-publish: ## publish to npm - cd dist/ngx-serial-console/  && npm publish   	
-#	cd dist/ngx-serial-console/  && npm publish   	
+publish: ## publish to npm - cd dist/ngx-simple-tools/  && npm publish   	
+#	cd dist/ngx-simple-tools/  && npm publish   	

--- a/angular.json
+++ b/angular.json
@@ -3,20 +3,20 @@
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
-    "ngx-simple-lib": {
+    "ngx-simple-tools": {
       "projectType": "library",
-      "root": "projects/ngx-simple-lib",
-      "sourceRoot": "projects/ngx-simple-lib/src",
+      "root": "projects/ngx-simple-tools",
+      "sourceRoot": "projects/ngx-simple-tools/src",
       "prefix": "lib",
       "architect": {
         "build": {
           "builder": "@angular/build:ng-packagr",
           "configurations": {
             "production": {
-              "tsConfig": "projects/ngx-simple-lib/tsconfig.lib.prod.json"
+              "tsConfig": "projects/ngx-simple-tools/tsconfig.lib.prod.json"
             },
             "development": {
-              "tsConfig": "projects/ngx-simple-lib/tsconfig.lib.json"
+              "tsConfig": "projects/ngx-simple-tools/tsconfig.lib.json"
             }
           },
           "defaultConfiguration": "production"
@@ -24,7 +24,7 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
-            "tsConfig": "projects/ngx-simple-lib/tsconfig.spec.json"
+            "tsConfig": "projects/ngx-simple-tools/tsconfig.spec.json"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ngx-simple-lib",
+  "name": "ngx-simple-tools",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ngx-simple-lib",
+      "name": "ngx-simple-tools",
       "version": "0.0.0",
       "dependencies": {
         "@angular/common": "^20.3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ngx-simple-lib",
+  "name": "ngx-simple-tools",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,8 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "paths": {
-      "ngx-simple-lib": [
-        "./dist/ngx-simple-lib"
+      "ngx-simple-tools": [
+        "./dist/ngx-simple-tools"
       ]
     },
     "noFallthroughCasesInSwitch": true,
@@ -30,10 +30,10 @@
   "files": [],
   "references": [
     {
-      "path": "./projects/ngx-simple-lib/tsconfig.lib.json"
+      "path": "./projects/ngx-simple-tools/tsconfig.lib.json"
     },
     {
-      "path": "./projects/ngx-simple-lib/tsconfig.spec.json"
+      "path": "./projects/ngx-simple-tools/tsconfig.spec.json"
     },
     {
       "path": "./projects/demo/tsconfig.app.json"


### PR DESCRIPTION
renamed project and lib to ngx-simple-tools, because ngx-simple-lib was taken
Always use npm-cli to search for names, registry search does not show libs in draft stage.